### PR TITLE
feat: correctly authenticate when releasing and use multi platform build

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -14,6 +14,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           persist-credentials: false
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v1
       - env:

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -33,6 +33,6 @@ jobs:
           docker buildx build \
             --output=type=registry \
             --platform linux/amd64,linux/arm64 \
-            --tag ghcr.io/ridedott/flatbuffers-builder:latest \
+            --tag ghcr.io/ridedott/flatbuffers-builder-docker/flatbuffers-builder:latest \
             --tag registry.hub.docker.com/ridedott/flatbuffers-builder:latest \
             .

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -14,33 +14,25 @@ jobs:
         uses: actions/checkout@v2
         with:
           persist-credentials: false
-      - name: Build
-        run: |
-          docker build \
-            --tag docker.pkg.github.com/ridedott/flatbuffers-builder-docker/flatbuffers-builder:latest \
-            --tag registry.hub.docker.com/ridedott/flatbuffers-builder:latest \
-            .
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v1
       - env:
+          DOCKER_BUILDKIT: 1
+          DOCKER_HUB_REGISTRY_USERNAME: ${{ secrets.DOCKER_HUB_REGISTRY_USERNAME }}
+          DOCKER_HUB_REGISTRY_PASSWORD: ${{ secrets.DOCKER_HUB_REGISTRY_PASSWORD }}
           GITHUB_REGISTRY_USERNAME: ${{ github.actor }}
-          GITHUB_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN_DOTTBOTT }}
-          DOCKER_HUB_REGISTRY_USERNAME:
-            ${{ secrets.DOCKER_HUB_REGISTRY_USERNAME }}
-          DOCKER_HUB_REGISTRY_PASSWORD:
-            ${{ secrets.DOCKER_HUB_REGISTRY_PASSWORD }}
-        name: Release
+          GITHUB_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        name: Build and release
         run: |
-          # GitHub Package Registry
-          echo $GITHUB_REGISTRY_PASSWORD | \
-            docker login docker.pkg.github.com \
-            --username $GITHUB_REGISTRY_USERNAME \
-            --password-stdin
-          docker push \
-            docker.pkg.github.com/ridedott/flatbuffers-builder-docker/flatbuffers-builder:latest
+          # GitHub Packages Registry
+          echo $GITHUB_REGISTRY_PASSWORD | docker login ghcr.io --username $GITHUB_REGISTRY_USERNAME --password-stdin
 
           # Docker Hub
-          echo $DOCKER_HUB_REGISTRY_PASSWORD | \
-            docker login registry.hub.docker.com \
-            --username $DOCKER_HUB_REGISTRY_USERNAME \
-            --password-stdin
-          docker push \
-            registry.hub.docker.com/ridedott/flatbuffers-builder:latest
+          echo $DOCKER_HUB_REGISTRY_PASSWORD | docker login registry.hub.docker.com --username $DOCKER_HUB_REGISTRY_USERNAME --password-stdin
+
+          docker buildx build \
+            --output=type=registry \
+            --platform linux/amd64,linux/arm64 \
+            --tag ghcr.io/ridedott/flatbuffers-builder:latest \
+            --tag registry.hub.docker.com/ridedott/flatbuffers-builder:latest \
+            .

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,6 +14,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           persist-credentials: false
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v1
       - env:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,5 +14,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           persist-credentials: false
-      - name: Build
-        run: docker build .
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - env:
+          DOCKER_BUILDKIT: 1
+        name: Build
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            .

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Docker image running with FlatBuffers compilers.
 ## Usage
 
 ```bash
-docker pull docker.pkg.github.com/ridedott/flatbuffers-builder-docker/flatbuffers-builder:latest
+docker pull ghcr.io/ridedott/flatbuffers-builder-docker/flatbuffers-builder:latest
 docker run ridedott/flatbuffers-builder:latest
 ```
 


### PR DESCRIPTION
So pkg.github has long been gone, we need to use ghcr.io now. Also this adds the multi-platform build for M1 chips (I think). This configuration puts it in line with the [firestore-emulator-docker](https://github.com/ridedott/firestore-emulator-docker/blob/master/.github/workflows/continuous-delivery.yaml) and [pubsub-emulator-docker](https://github.com/ridedott/pubsub-emulator-docker/blob/master/.github/workflows/continuous-delivery.yaml).

This Pull Request fulfills the following requirements:

- [x] The commit message follows our guidelines.
- [x] Does not affect documentation or it has been added or updated.

<!--
Example: Resolves #1234

This allows PRs to be resolved automatically once the PR is merged to a base
branch. The following line should be removed if the PR does not affect any open
issues.
-->

Resolves #
