### PR TITLE
ci: migrate to Blacksmith runners

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Migrates CI jobs from GitHub-hosted runners to Blacksmith.

Mapping:
- ubuntu-latest -> blacksmith-2vcpu-ubuntu-2404 (lint/test jobs -> blacksmith-4vcpu-ubuntu-2404)
- ubuntu-latest-cpuN -> blacksmith-Nvcpu-ubuntu-2404

Only runs-on lines changed. Same migration as functions#15033 and k8s-applications#8508.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
